### PR TITLE
Add ability to skip sha checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Man pages - While this isn't a particularly complicated tool to use, it would be
 
 Proper output formatting/handling - console does a pretty good job of detecting if we're piping the output or running through a terminal that doesn't support colored output but there are instances where we seem to break things. One such instance is if we try to run install and pipe to a file. stderr is still written but we end up with the progress bar ending up in the file as a string of escape codes
 
-Flatpack support - There is no flatpack support at the moment.
-
 Custom installs - There is no support for custom installs at the moment. Currently only wine-ge-custom and proton-ge-custom are supported.
 
 User configuration - There is no support for user configuration of colors or custom install locations at the moment. Wine and proton builds will be installed into the lutris and proton compatibility/runner directories respectively.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,28 +40,28 @@ pub fn build_cli() -> Command {
     Command::new("protonctl")
         .subcommand_precedence_over_arg(true)
         .subcommand_required(true)
+        .arg(
+            Arg::new("type")
+                .short('t')
+                .long("type")
+                .action(ArgAction::Set)
+                .value_parser(clap::builder::EnumValueParser::<InstallTypeCmd>::new())
+                .default_value("proton")
+                .global(true)
+                .required(false)
+                .help("The type install type to use"),
+        )
+        .arg(
+            Arg::new("flatpak")
+                .short('f')
+                .long("flatpak")
+                .action(ArgAction::SetTrue)
+                .required(false)
+                .default_value("false")
+                .help("Use flatpak")
+        )
         .subcommand(
             Command::new("list")
-                .arg(
-                    Arg::new("type")
-                        .short('t')
-                        .long("type")
-                        .action(ArgAction::Set)
-                        .value_parser(clap::builder::EnumValueParser::<InstallTypeCmd>::new())
-                        .default_value("proton")
-                        .global(true)
-                        .required(false)
-                        .help("The type install type to use"),
-                )
-                .arg(
-                    Arg::new("flatpak")
-                        .short('f')
-                        .long("flatpak")
-                        .action(ArgAction::SetTrue)
-                        .required(false)
-                        .default_value("false")
-                        .help("Use flatpak")
-                )
                 .arg(
                     Arg::new("number")
                         .action(ArgAction::Set)
@@ -96,26 +96,6 @@ pub fn build_cli() -> Command {
         .subcommand(
             Command::new("remove")
                 .arg(
-                    Arg::new("type")
-                        .short('t')
-                        .long("type")
-                        .action(ArgAction::Set)
-                        .value_parser(clap::builder::EnumValueParser::<InstallTypeCmd>::new())
-                        .default_value("proton")
-                        .global(true)
-                        .required(false)
-                        .help("The type install type to use"),
-                )
-                .arg(
-                    Arg::new("flatpak")
-                        .short('f')
-                        .long("flatpak")
-                        .action(ArgAction::SetTrue)
-                        .required(false)
-                        .default_value("false")
-                        .help("Use flatpak")
-                )
-                .arg(
                     Arg::new("cache")
                         .action(ArgAction::SetTrue)
                         .default_value("false")
@@ -147,24 +127,12 @@ pub fn build_cli() -> Command {
             Command::new("install")
                 .arg(Arg::new("install_version").required(true))
                 .arg(
-                    Arg::new("type")
-                        .short('t')
-                        .long("type")
-                        .action(ArgAction::Set)
-                        .value_parser(clap::builder::EnumValueParser::<InstallTypeCmd>::new())
-                        .default_value("proton")
-                        .global(true)
-                        .required(false)
-                        .help("The type install type to use"),
+                    Arg::new("skip_sha_check")
+                    .action(ArgAction::SetTrue)
+                    .default_value("false")
+                    .required(false)
+                    .long("skip-sha-check")
+                    .help("Don't attempt to fetch or validate the sha")
                 )
-                .arg(
-                    Arg::new("flatpak")
-                        .short('f')
-                        .long("flatpak")
-                        .action(ArgAction::SetTrue)
-                        .required(false)
-                        .default_value("false")
-                        .help("Use flatpak")
-                ),
         )
 }

--- a/src/cli_utils.rs
+++ b/src/cli_utils.rs
@@ -105,23 +105,25 @@ impl InstallTypeCmd {
 
 pub fn command_to_struct(cmd: &Command) -> anyhow::Result<Box<dyn Run>> {
     let matches = cmd.clone().get_matches();
+    let flatpak = *matches.get_one::<bool>("flatpak").unwrap();
+    let install_type = *matches.get_one::<InstallTypeCmd>("type").unwrap();
     match matches.subcommand() {
         Some(("install", sub_i)) => Ok(Box::new(install::Install::new(
             sub_i.get_one::<String>("install_version").unwrap().clone(),
-            *sub_i.get_one::<bool>("flatpak").unwrap(),
-            *sub_i.get_one::<InstallTypeCmd>("type").unwrap(),
+            flatpak,
+            *sub_i.get_one::<bool>("skip_sha_check").unwrap(),
+            install_type,
         ))),
         Some(("list", sub_l)) => Ok(Box::new(list::List::new(
             *sub_l.get_one::<u8>("number").unwrap(),
             *sub_l.get_one::<u8>("page").unwrap(),
             *sub_l.get_one::<bool>("local").unwrap(),
-            *sub_l.get_one::<bool>("flatpak").unwrap(),
-            *sub_l.get_one::<InstallTypeCmd>("type").unwrap(),
+            flatpak,
+            install_type,
         ))),
         Some(("remove", sub_r)) => {
             let cache = *sub_r.get_one::<bool>("cache").unwrap();
             let all = *sub_r.get_one::<bool>("all").unwrap();
-            let flatpak = *sub_r.get_one::<bool>("flatpak").unwrap();
             let install_version = if let Some(v) = sub_r.get_one::<String>("install_version") {
                 v.clone()
             } else {
@@ -135,7 +137,7 @@ pub fn command_to_struct(cmd: &Command) -> anyhow::Result<Box<dyn Run>> {
                 cache,
                 all,
                 flatpak,
-                *sub_r.get_one::<InstallTypeCmd>("type").unwrap(),
+                install_type,
                 install_version,
             )))
         }


### PR DESCRIPTION
This adds an argument to install to skip sha checking. This required the rearranging/rethinking of how asset ids are fetched. This also moves the type and flatpak arguments.